### PR TITLE
Solves the issue with clojure 1.4.0, where as-str is not found.

### DIFF
--- a/src/clj_airbrake/core.clj
+++ b/src/clj_airbrake/core.clj
@@ -37,7 +37,7 @@
   "converts v to a string and escapes html entities"
   [v]
   (when v
-    (escape (as-str v) {\< "&lt;" \> "&gt;" \& "&amp;" \" "&quot;" \' "&apos;"})))
+    (escape (name v) {\< "&lt;" \> "&gt;" \& "&amp;" \" "&quot;" \' "&apos;"})))
 
 (defn- map->xml-vars [hash-map sub-map-key]
   (when-let [sub-map (sub-map-key hash-map)]


### PR DESCRIPTION
I was having an issue using the library version where the as-str function was not found on clojure 1.4.0 / 1.5.1.
