### PR TITLE
Fix key name for the environment-name

### DIFF
--- a/src/clj_airbrake/core.clj
+++ b/src/clj_airbrake/core.clj
@@ -70,7 +70,7 @@
      (validate-config airbrake-config)
      (if (is-ignored-environment? environment-name ignored-environments)
        (future nil)
-       (-> (make-notice throwable (merge extra-data {:environment environment-name :root-directory root-directory}))
+       (-> (make-notice throwable (merge extra-data {:environment-name environment-name :root-directory root-directory}))
            (send-notice-async callback project api-key))))))
 
 (defn notify


### PR DESCRIPTION
The environment-name wasn't being sent to Airbrake because there was
disagreement about the key name between two functions.