### PR TITLE
Getting http-kit to use an alternate threadpool

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-airbrake "3.0.3"
+(defproject clj-airbrake "3.0.4"
   :description "Airbrake Client"
   :min-lein-version "2.0.0"
   :url "https://github.com/bmabey/clj-airbrake"


### PR DESCRIPTION
The `thread-pool` code is an almost direct copy from [http-kit](https://github.com/http-kit/http-kit/blob/master/src/org/httpkit/client.clj#L86)

It might be necessary to tune the maximum number of thread.

Fixes #30 