### PR TITLE
Filter sensitive params - feedback requested

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,17 @@ Below is an example of the `airbrake-configuration`:
  :root-dirctory "/app/dir" ;optional
 
  :ignored-environments #{"test" "development"} ;optional but defaults to 'development' and 'test'
+ :sensitive-environment-variables [#"pass"] ;optional
+ :sensitive-params [#"pass"] ;optional
  }
 ```
 Both `api-key` and `project` can both be found in the settings for your project in the Airbrake website.
+
+### Senstive data
+
+There are times that your environment and params may contain sensitive data (e.g. passwords) that you don't want sent to airbrake. We try to provide sensible defaults for this but can be configured throught the keys `sensitive-environment-variables` and `sensitive-params`. Both values are a vector of regexes that will be tested against the keys in your environment variable and params.
+
+### Currying
 
 Unsurprisingly, passing the configuration to `notify` for every single call could be painful. So a convinience macro is provided.
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-airbrake "3.0.4"
+(defproject clj-airbrake "3.1.0"
   :description "Airbrake Client"
   :min-lein-version "2.0.0"
   :url "https://github.com/bmabey/clj-airbrake"

--- a/src/clj_airbrake/core.clj
+++ b/src/clj_airbrake/core.clj
@@ -89,8 +89,8 @@
 
 (def defaults
   {:ignored-environments #{"test" "development"}
-   :sensitive-environment-variables [#"PASSWORD"]
-   :sensitive-params [#"password"]})
+   :sensitive-environment-variables [#"(?i)PASS" #"(?i)SECRET" #"(?i)TOKEN" #"(?i)AWS_ACCESS_KEY_ID" #"(?i)AWS_SECRET_ACCESS_KEY"]
+   :sensitive-params [#"(?i)pass"]})
 
 (defn notify-async
   ([airbrake-config callback throwable]

--- a/src/clj_airbrake/core.clj
+++ b/src/clj_airbrake/core.clj
@@ -29,8 +29,11 @@
 (defn sensitive? [preds [k _]]
   ((apply some-fn preds) k))
 
+(defn matches? [r k]
+  (re-find r (name k)))
+
 (defn scrub [regexes m]
-  (let [preds (map #(partial re-matches %)  regexes)]
+  (let [preds (map #(partial matches? %) regexes)]
     (->> m
          (remove (partial sensitive? preds))
          (into {}))))


### PR DESCRIPTION
Often environment variable and params contain information that can be sensitive. In these situations it's nice to provide a simple way to filter out this sensitive data and provide sensible defaults in the hope that people don't accidentally send through this information.