### PR TITLE
fix argument order on 3-arg version of notify-async

### DIFF
--- a/src/clj_airbrake/core.clj
+++ b/src/clj_airbrake/core.clj
@@ -98,7 +98,7 @@
 
 (defn notify-async
   ([airbrake-config callback throwable]
-   (notify-async callback airbrake-config throwable {}))
+   (notify-async airbrake-config callback throwable {}))
   ([airbrake-config callback throwable extra-data]
    (let [{:keys [environment-name api-key project host ignored-environments root-directory sensitive-environment-variables sensitive-params]} (merge defaults airbrake-config)
          notice-data (merge extra-data {:environment-name environment-name :root-directory root-directory})]


### PR DESCRIPTION
It's calling the 4-arg version with the arguments in the wrong order, so it would never work.